### PR TITLE
Setup GitHub Actions for Testing, Building, and Codecov

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,40 @@
+name: Node.js Test and Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 15.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          **/node_modules
+        key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run unit tests and generate coverage report
+      run: npm test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+
+    - name: Build
+      run: npm run build

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -29,7 +29,7 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
     - name: Install dependencies
-      run: npm ci
+      run: npm install
 
     - name: Run unit tests and generate coverage report
       run: npm test

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <div align="center">
 
-![GitHub Actions](https://img.shields.io/github/workflow/status/rocket-booster/rocket-booster/node?style=for-the-badge)
-[![Codecov Coverage](https://img.shields.io/codecov/c/github/rocket-booster/rocket-booster?style=for-the-badge)](https://app.codecov.io/gh/rocket-booster/rocket-booster/)
-[![Package version](https://img.shields.io/npm/v/rocket-booster?style=for-the-badge)](https://www.npmjs.com/package/rocket-booster)
-[![Bundle size](https://img.shields.io/bundlephobia/min/rocket-booster?style=for-the-badge)](https://www.npmjs.com/package/rocket-booster)
+![GitHub Actions](https://img.shields.io/github/workflow/status/rocket-booster/rocket-booster/Node.js%20Test%20and%20Build?style=for-the-badge&logo=github)
+[![Codecov Coverage](https://img.shields.io/codecov/c/github/rocket-booster/rocket-booster?style=for-the-badge&logo=codecov)](https://app.codecov.io/gh/rocket-booster/rocket-booster/)
+[![Package version](https://img.shields.io/npm/v/rocket-booster?style=for-the-badge&logo=npm&color=red)](https://www.npmjs.com/package/rocket-booster)
+[![Bundle size](https://img.shields.io/bundlephobia/min/rocket-booster?style=for-the-badge&logo=webpack)](https://www.npmjs.com/package/rocket-booster)
 
 [![forthebadge](https://forthebadge.com/images/badges/made-with-typescript.svg)](https://forthebadge.com)
 [![forthebadge](https://forthebadge.com/images/badges/ctrl-c-ctrl-v.svg)](https://forthebadge.com)


### PR DESCRIPTION
- [x] Build and test the source code on latest Ubuntu and Node.js 12.x, 14.x, 15.x
- [x] Generate code coverage report with `jest --coverage` and upload it to Codecov
- [x] Cache dependencies with `actions/cache@v2` to improve performance
- [x] Update badges in README.md